### PR TITLE
fixing compile error with newest Arduino update

### DIFF
--- a/LiquidCrystal_I2C.h
+++ b/LiquidCrystal_I2C.h
@@ -57,7 +57,7 @@
  * The backlight is on by default, since that is the most likely operating mode in
  * most cases.
  */
-class LiquidCrystal_I2C : public Print {
+class LiquidCrystal_I2C : public arduino::Print {
 public:
 	/**
 	 * Constructor


### PR DESCRIPTION
an update on MEGA AVR caused compile errors using this library.
Explicitly stating the namespace fixes the issue